### PR TITLE
QOL Updates 

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ From the root directory of the repository, run the following command:
 docker-compose up
 ```
 
+When iterating, rebuilding and composing is necessary. The following command is a convenience one line
+```bash
+docker compose build --no-cache --pull && docker compose up
+```
+
 ### Running Locally
 
 Running the bot locally requires a few additional steps.


### PR DESCRIPTION
This PR fixes some stuff that I missed on the first time around.

1. Removes the uptime from available pcs (ie don't show 0h 0m) 
2. Bold pc uptime for pcs that are able to be kicked off (>2 hrs and not in a reservation)
3. Display upcoming reservations in the pcs command within a threshold value (threshold set to 30 mins right now, ie if a PC is available but is reserved within next 30 mins that context is displayed)
4. Updated all time functions to use CST so the reservations fetch is not based off of UTC (previously past 6pm reservations command would show the next day)