### PR TITLE
moderation cog, purge command

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -23,7 +23,8 @@ cogs_list = [
     "pcs",
     "game",
     "connections",
-    "pugs"
+    "pugs",
+    "moderation"
 ]
 
 for cog in cogs_list:

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -1,0 +1,30 @@
+import discord
+from discord import default_permissions
+from discord.ext import commands
+
+from utils import config
+
+GUILD_ID = config.secrets["discord"]["guild_id"]
+
+class Moderation(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @discord.slash_command(
+        name="purge",
+        description="Delete recent messages",
+        guild_ids=[GUILD_ID]
+    )
+    @default_permissions(manage_messages=True)
+    async def purge(self, ctx: discord.ApplicationContext, amount: int):
+        if not ctx.channel.permissions_for(ctx.author).manage_messages:
+            await ctx.respond("You do not have permission to use this command.", ephemeral=True)
+            return
+
+        await ctx.defer(ephemeral=True)
+        deleted = await ctx.channel.purge(limit=amount)
+        await ctx.followup.send(f"Deleted {len(deleted)} messages.", ephemeral=True)
+
+
+def setup(bot):
+    bot.add_cog(Moderation(bot))


### PR DESCRIPTION
i wanted to be able to mass delete messages

user needs "manage messages" via role (did not work via channel specific perms in my testing) to be able to use /purge

| pre purge | post purge |
|--------|-------|
| ![Before](https://cdn.discordapp.com/attachments/859639780861804544/1501471884636852374/image.png?ex=69fc3229&is=69fae0a9&hm=9d2864579a66f378303efb609fa10fc710792508eda6a13b2a7318e7fa6ebf17&) | ![After](https://cdn.discordapp.com/attachments/859639780861804544/1501471884934516836/image.png?ex=69fc3229&is=69fae0a9&hm=ff9c968083a61f9342006c6c990bfd8d72cbacbeacfdafbf81362207bc34308d&) |