### PR TITLE
lock, unlock, and slowmode commands

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -24,7 +24,8 @@ cogs_list = [
     "game",
     "connections",
     "pugs",
-    "moderation"
+    "moderation",
+    "presence"
 ]
 
 for cog in cogs_list:

--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -9,7 +9,6 @@ from utils import config
 
 GUILD_ID = config.secrets["discord"]["guild_id"]
 TYST_STICKER_ID = 1500307023814721646
-STREAM_LINK = "https://twitch.tv/NorthwesternEsports"
 
 class Fun(commands.Cog):
     def __init__(self, bot):
@@ -19,29 +18,7 @@ class Fun(commands.Cog):
             "text_unmute_task": None,
             "voice_unmute_task": None,
             "original_text_permissions": {},  # {channel_id: send_messages_value}
-        }
-
-    @discord.slash_command(
-            name="status",
-            description="Changes status of the bot",
-            guild_ids=[GUILD_ID],
-    )
-    async def color(self, 
-                    ctx: discord.ApplicationContext, 
-                    type: str = discord.Option(str, "What kind of status?", choices=["streaming", "default", "custom"]),
-                    status: str = ""):
-        if type == "streaming":
-            if status == "":
-                status = "NU Esports is live!"
-            await self.bot.change_presence(activity=discord.Streaming(name=status, url=STREAM_LINK))
-            await ctx.respond("🚨 Showing stream in status!", ephemeral=True)
-        elif type == "custom":
-            await self.bot.change_presence(activity=discord.Activity(type=discord.ActivityType.playing, name=status))
-            await ctx.respond(f"📝 Changed status to \"{status}\"!", ephemeral=True)
-        else: #default
-            await self.bot.change_presence(activity=discord.Activity(type=discord.ActivityType.listening, name="UNCA / Composure"))
-            await ctx.respond("🤖 Changed to default status!")
-        
+        }      
 
     @discord.slash_command(
         name="mutehannah",

--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -9,6 +9,7 @@ from utils import config
 
 GUILD_ID = config.secrets["discord"]["guild_id"]
 TYST_STICKER_ID = 1500307023814721646
+STREAM_LINK = "https://twitch.tv/NorthwesternEsports"
 
 class Fun(commands.Cog):
     def __init__(self, bot):
@@ -19,6 +20,28 @@ class Fun(commands.Cog):
             "voice_unmute_task": None,
             "original_text_permissions": {},  # {channel_id: send_messages_value}
         }
+
+    @discord.slash_command(
+            name="status",
+            description="Changes status of the bot",
+            guild_ids=[GUILD_ID],
+    )
+    async def color(self, 
+                    ctx: discord.ApplicationContext, 
+                    type: str = discord.Option(str, "What kind of status?", choices=["streaming", "default", "custom"]),
+                    status: str = ""):
+        if type == "streaming":
+            if status == "":
+                status = "NU Esports is live!"
+            await self.bot.change_presence(activity=discord.Streaming(name=status, url=STREAM_LINK))
+            await ctx.respond("🚨 Showing stream in status!", ephemeral=True)
+        elif type == "custom":
+            await self.bot.change_presence(activity=discord.Activity(type=discord.ActivityType.playing, name=status))
+            await ctx.respond(f"📝 Changed status to \"{status}\"!", ephemeral=True)
+        else: #default
+            await self.bot.change_presence(activity=discord.Activity(type=discord.ActivityType.listening, name="UNCA / Composure"))
+            await ctx.respond("🤖 Changed to default status!")
+        
 
     @discord.slash_command(
         name="mutehannah",

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -75,7 +75,7 @@ class Moderation(commands.Cog):
         if seconds:
             await ctx.respond(f"🐌 {seconds}-second Slowmode enabled.")
         else:
-            await ctx.respond(f"🐛 Slowmode disabled!")
+            await ctx.respond("🐛 Slowmode disabled!")
 
 def setup(bot):
     bot.add_cog(Moderation(bot))

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -26,5 +26,37 @@ class Moderation(commands.Cog):
         await ctx.followup.send(f"Deleted {len(deleted)} messages.", ephemeral=True)
 
 
+    @discord.slash_command(
+        name="lock",
+        description="Locks a channel",
+        guild_ids=[GUILD_ID]
+    )
+    @default_permissions(manage_channels=True)
+    async def lock(self, ctx: discord.ApplicationContext):
+        if not ctx.channel.permissions_for(ctx.author).manage_channels:
+            await ctx.respond("You do not have permission to use this command.", ephemeral=True)
+            return
+        
+        overwrite = ctx.channel.overwrites_for(ctx.guild.default_role)
+        overwrite.send_messages = False 
+        await ctx.channel.set_permissions(ctx.guild.default_role, overwrite=overwrite)
+        await ctx.respond("🔒 Channel locked.")
+
+    @discord.slash_command(
+        name="unlock",
+        description="Locks a channel",
+        guild_ids=[GUILD_ID]
+    )
+    @default_permissions(manage_channels=True)
+    async def unlock(self, ctx: discord.ApplicationContext):
+        if not ctx.channel.permissions_for(ctx.author).manage_channels:
+            await ctx.respond("You do not have permission to use this command.", ephemeral=True)
+            return
+        
+        overwrite = ctx.channel.overwrites_for(ctx.guild.default_role)
+        overwrite.send_messages = True 
+        await ctx.channel.set_permissions(ctx.guild.default_role, overwrite=overwrite)
+        await ctx.respond("🔓 Channel unlocked.", ephemeral=True)
+
 def setup(bot):
     bot.add_cog(Moderation(bot))

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -28,33 +28,35 @@ class Moderation(commands.Cog):
 
     @discord.slash_command(
         name="lock",
-        description="Locks a channel",
+        description="Locks a channel (hiding optional). /Unlock to undo",
         guild_ids=[GUILD_ID]
     )
     @default_permissions(manage_channels=True)
-    async def lock(self, ctx: discord.ApplicationContext):
+    async def lock(self, ctx: discord.ApplicationContext, hide: bool=True):
         if not ctx.channel.permissions_for(ctx.author).manage_channels:
             await ctx.respond("You do not have permission to use this command.", ephemeral=True)
             return
         
         overwrite = ctx.channel.overwrites_for(ctx.guild.default_role)
         overwrite.send_messages = False 
+        if hide: overwrite.view_channel = False
         await ctx.channel.set_permissions(ctx.guild.default_role, overwrite=overwrite)
         await ctx.respond("🔒 Channel locked.")
 
     @discord.slash_command(
         name="unlock",
-        description="Locks a channel",
+        description="Unlocks a channel (unhiding optional)",
         guild_ids=[GUILD_ID]
     )
     @default_permissions(manage_channels=True)
-    async def unlock(self, ctx: discord.ApplicationContext):
+    async def unlock(self, ctx: discord.ApplicationContext, unhide: bool=True):
         if not ctx.channel.permissions_for(ctx.author).manage_channels:
             await ctx.respond("You do not have permission to use this command.", ephemeral=True)
             return
         
         overwrite = ctx.channel.overwrites_for(ctx.guild.default_role)
-        overwrite.send_messages = True 
+        overwrite.send_messages = True
+        if unhide: overwrite.view_channel = True
         await ctx.channel.set_permissions(ctx.guild.default_role, overwrite=overwrite)
         await ctx.respond("🔓 Channel unlocked.", ephemeral=True)
 

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -60,5 +60,22 @@ class Moderation(commands.Cog):
         await ctx.channel.set_permissions(ctx.guild.default_role, overwrite=overwrite)
         await ctx.respond("🔓 Channel unlocked.", ephemeral=True)
 
+    @discord.slash_command(
+        name="slowmode",
+        description="Applies a slowmode to a channel.",
+        guild_ids=[GUILD_ID]
+    )
+    @default_permissions(manage_channels=True)
+    async def slowmode(self, ctx: discord.ApplicationContext, seconds: int):
+        if not ctx.channel.permissions_for(ctx.author).manage_channels:
+            await ctx.respond("You do not have permission to use this command.", ephemeral=True)
+            return
+    
+        await ctx.channel.edit(slowmode_delay=seconds)
+        if seconds:
+            await ctx.respond(f"🐌 {seconds}-second Slowmode enabled.")
+        else:
+            await ctx.respond(f"🐛 Slowmode disabled!")
+
 def setup(bot):
     bot.add_cog(Moderation(bot))

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -39,7 +39,8 @@ class Moderation(commands.Cog):
         
         overwrite = ctx.channel.overwrites_for(ctx.guild.default_role)
         overwrite.send_messages = False 
-        if hide: overwrite.view_channel = False
+        if hide: 
+            overwrite.view_channel = False
         await ctx.channel.set_permissions(ctx.guild.default_role, overwrite=overwrite)
         await ctx.respond("🔒 Channel locked.")
 
@@ -56,7 +57,8 @@ class Moderation(commands.Cog):
         
         overwrite = ctx.channel.overwrites_for(ctx.guild.default_role)
         overwrite.send_messages = True
-        if unhide: overwrite.view_channel = True
+        if unhide: 
+            overwrite.view_channel = True
         await ctx.channel.set_permissions(ctx.guild.default_role, overwrite=overwrite)
         await ctx.respond("🔓 Channel unlocked.", ephemeral=True)
 

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -39,7 +39,8 @@ class Moderation(commands.Cog):
         
         overwrite = ctx.channel.overwrites_for(ctx.guild.default_role)
         overwrite.send_messages = False 
-        if hide: overwrite.view_channel = False
+        if hide:
+            overwrite.view_channel = False
         await ctx.channel.set_permissions(ctx.guild.default_role, overwrite=overwrite)
         await ctx.respond("🔒 Channel locked.")
 
@@ -56,7 +57,8 @@ class Moderation(commands.Cog):
         
         overwrite = ctx.channel.overwrites_for(ctx.guild.default_role)
         overwrite.send_messages = True
-        if unhide: overwrite.view_channel = True
+        if unhide: 
+            overwrite.view_channel = True
         await ctx.channel.set_permissions(ctx.guild.default_role, overwrite=overwrite)
         await ctx.respond("🔓 Channel unlocked.", ephemeral=True)
 

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -39,8 +39,7 @@ class Moderation(commands.Cog):
         
         overwrite = ctx.channel.overwrites_for(ctx.guild.default_role)
         overwrite.send_messages = False 
-        if hide:
-            overwrite.view_channel = False
+        if hide: overwrite.view_channel = False
         await ctx.channel.set_permissions(ctx.guild.default_role, overwrite=overwrite)
         await ctx.respond("🔒 Channel locked.")
 
@@ -57,8 +56,7 @@ class Moderation(commands.Cog):
         
         overwrite = ctx.channel.overwrites_for(ctx.guild.default_role)
         overwrite.send_messages = True
-        if unhide: 
-            overwrite.view_channel = True
+        if unhide: overwrite.view_channel = True
         await ctx.channel.set_permissions(ctx.guild.default_role, overwrite=overwrite)
         await ctx.respond("🔓 Channel unlocked.", ephemeral=True)
 

--- a/cogs/presence.py
+++ b/cogs/presence.py
@@ -1,35 +1,34 @@
-import asyncio
 import discord
-from discord import default_permissions
+import random
 from discord.ext import commands, tasks
 
 from utils import config
+from utils.statuses import load_statuses
 
 GUILD_ID = config.secrets["discord"]["guild_id"]
 BOT_DEVS = config.config["bot_devs"]
 STREAM_LINK = "https://twitch.tv/NorthwesternEsports"
-
-STATUSES = [
-    discord.Activity(type=discord.ActivityType.listening, name="UNCA / Composure"),
-    discord.Activity(type=discord.ActivityType.listening, name="Weston Super Mare"),
-    discord.Activity(type=discord.ActivityType.listening, name="Flyen"),
-    discord.Activity(type=discord.ActivityType.listening, name="Polo Ponies")
-]
+STREAM_TEAM_ROLE_ID = 1170159172667584572
+CYCLE_MINS = 3
 
 class Presence(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.index = 0
+        self.lastindex = -1
+        self.statuses = load_statuses()
 
     @commands.Cog.listener()
     async def on_ready(self):
         if not self.cycle_status.is_running():
             self.cycle_status.start()
 
-    @tasks.loop(minutes=0.1)
+    @tasks.loop(minutes=CYCLE_MINS)
     async def cycle_status(self):
-        await self.bot.change_presence(activity=STATUSES[self.index])
-        self.index = (self.index + 1) % len(STATUSES)
+        while self.index == self.lastindex: #basic shuffle, won't do something twice in a row.
+            self.index = random.randint(0,len(self.statuses)-1)
+        await self.bot.change_presence(activity=self.statuses[self.index])
+        self.lastindex = self.index
 
     @discord.slash_command(
             name="status",
@@ -40,7 +39,7 @@ class Presence(commands.Cog):
                     ctx: discord.ApplicationContext, 
                     type: str = discord.Option(str, "What kind of status?", choices=["streaming", "default", "custom"]),
                     status: str = ""):
-        if ctx.author.id not in BOT_DEVS:
+        if (ctx.author.id not in BOT_DEVS) and (not discord.utils.get(ctx.author.roles, id=STREAM_TEAM_ROLE_ID)):
             await ctx.respond("You don't have permission to use this command.", ephemeral=True)
             return
         
@@ -54,11 +53,18 @@ class Presence(commands.Cog):
         elif type == "custom":
             self.cycle_status.stop()
             await self.bot.change_presence(activity=discord.Activity(type=discord.ActivityType.playing, name=status))
-            await ctx.respond(f"📝 Changed status to \"{status}\"!", ephemeral=True)
+            if status == "":
+                await ctx.respond("🔮 Cleared status!", ephemeral=True)
+            else:
+                await ctx.respond(f"📝 Changed status to \"{status}\"!", ephemeral=True)
 
         else: #default
-            self.cycle_status.start()
-            await ctx.respond("🤖 Resumed cycling status!")
+            try:
+                self.cycle_status.start()
+            except RuntimeError:
+                await ctx.respond("❌ Something went wrong. Try again!", ephemeral=True)
+                return
+            await ctx.respond("🤖 Resumed cycling status!", ephemeral=True)
 
 def setup(bot):
     bot.add_cog(Presence(bot))

--- a/cogs/presence.py
+++ b/cogs/presence.py
@@ -1,0 +1,64 @@
+import asyncio
+import discord
+from discord import default_permissions
+from discord.ext import commands, tasks
+
+from utils import config
+
+GUILD_ID = config.secrets["discord"]["guild_id"]
+BOT_DEVS = config.config["bot_devs"]
+STREAM_LINK = "https://twitch.tv/NorthwesternEsports"
+
+STATUSES = [
+    discord.Activity(type=discord.ActivityType.listening, name="UNCA / Composure"),
+    discord.Activity(type=discord.ActivityType.listening, name="Weston Super Mare"),
+    discord.Activity(type=discord.ActivityType.listening, name="Flyen"),
+    discord.Activity(type=discord.ActivityType.listening, name="Polo Ponies")
+]
+
+class Presence(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.index = 0
+
+    @commands.Cog.listener()
+    async def on_ready(self):
+        if not self.cycle_status.is_running():
+            self.cycle_status.start()
+
+    @tasks.loop(minutes=0.1)
+    async def cycle_status(self):
+        await self.bot.change_presence(activity=STATUSES[self.index])
+        self.index = (self.index + 1) % len(STATUSES)
+
+    @discord.slash_command(
+            name="status",
+            description="Changes status of the bot",
+            guild_ids=[GUILD_ID],
+    )
+    async def status(self, 
+                    ctx: discord.ApplicationContext, 
+                    type: str = discord.Option(str, "What kind of status?", choices=["streaming", "default", "custom"]),
+                    status: str = ""):
+        if ctx.author.id not in BOT_DEVS:
+            await ctx.respond("You don't have permission to use this command.", ephemeral=True)
+            return
+        
+        if type == "streaming":
+            self.cycle_status.stop()
+            if status == "":
+                status = "NU Esports is live!"
+            await self.bot.change_presence(activity=discord.Streaming(name=status, url=STREAM_LINK))
+            await ctx.respond("🚨 Showing stream in status!", ephemeral=True)
+
+        elif type == "custom":
+            self.cycle_status.stop()
+            await self.bot.change_presence(activity=discord.Activity(type=discord.ActivityType.playing, name=status))
+            await ctx.respond(f"📝 Changed status to \"{status}\"!", ephemeral=True)
+
+        else: #default
+            self.cycle_status.start()
+            await ctx.respond("🤖 Resumed cycling status!")
+
+def setup(bot):
+    bot.add_cog(Presence(bot))

--- a/statuses.yaml
+++ b/statuses.yaml
@@ -108,6 +108,18 @@ statuses:
 
   - type: listening
     name: "whats up babe?"
+
+  - type: watching
+    name: "this is the bare minimum."
+
+  - type: listening
+    name: "dark stamour"
+
+  - type: listening
+    name: "light findler"
+
+  - type: listening
+    name: "themes and such"
     
   # God Save the Three - glaive
   - type: listening

--- a/statuses.yaml
+++ b/statuses.yaml
@@ -1,0 +1,173 @@
+# statuses:
+#   - type: <type> (lowercase)
+#     name: "<text>"
+
+# try to keep them short, discord cuts them off.
+# these are not blank statuses like regular users get.
+# they're the "playing ____" type thing, so they get cut off quick. 
+
+statuses:
+
+  # boring informational ones
+  - type: playing
+    name: "thenexusnexus.vercel.app"
+
+  # shitposts
+  - type: playing
+    name: "stoppokingmeyoupieceofshitillfuckingkillyou"
+
+  - type: listening
+    name: "D.VA DIFFERENTIAL! D.VA DIFFERENTIAL!!"
+
+  - type: listening
+    name: "WHAT IS WRONG WITH THESE PEOPLE? Oh my GOD..."
+
+  - type: listening
+    name: "nt amir. 🫨"
+
+  - type: listening
+    name: "markus tell- markus tell rowland to k-"
+
+  - type: listening
+    name: "siddharth i 𝙝𝙖𝙩𝙚 you"
+
+  - type: listening
+    name: "amimi my burger"
+
+  - type: listening
+    name: "if i get this kill, im not actually racist"
+
+  - type: listening
+    name: "男人的嘴 骗人的鬼"
+
+  - type: listening
+    name: "a man's words are the devil's lies."
+
+  - type: listening
+    name: "all men do is lie"
+
+  - type: listening
+    name: "the snow goose need not bathe to make itself white. neither need you do anything but be yourself."
+
+  - type: playing
+    name: "masculine macholivia"
+
+  - type: playing
+    name: "i think gay people should be jolly at the christmas tree"
+
+  - type: listening
+    name: "we have dead by daylight at home"
+
+  - type: playing
+    name: "\"We are slop piggies, give us more gruel for our tummies.\""
+
+  - type: listening
+    name: "fuyckj mchungeus life"
+
+  - type: listening
+    name: "i love frieren: beyond journey's end"
+
+  - type: listening
+    name: "that's my aura"
+
+  - type: listening
+    name: "helo its me sidart"
+
+  - type: listening
+    name: "u look like u would steal ur own lunch money"
+
+  - type: listening
+    name: "Nah, I'd win."
+
+  - type: listening
+    name: "shannon tan reportedly failed the jump for the beef"
+
+  - type: listening
+    name: "what is cum time?"
+
+  - type: listening
+    name: "i imagine you as patrick from spongebob with the drool in his mouth whenever i read things u type"
+
+  - type: listening
+    name: "i hope god smites me for my failures" #https://twitter.com/cabby/status/1908729945154871315
+
+  - type: playing
+    name: "my favorite emojis are 🦦, 🐛, and 💐"
+
+  - type: listening
+    name: "happy birthday hannah"
+
+  - type: listening
+    name: "whats up family"
+
+  - type: watching
+    name: "SIDDHARTH DIAMOND ON LEAGUE 2026"
+
+  - type: listening
+    name: "domain expansion: the lions den 🦁"
+
+  - type: listening
+    name: "whats up babe?"
+    
+  # God Save the Three - glaive
+  - type: listening
+    name: "🎵 𝓖𝓸𝓭 𝓼𝓪𝓿𝓮 𝓽𝓱𝓮 𝓽𝓱𝓻𝓮𝓮" 
+
+  - type: listening
+    name: "🎵 right here, in Weston Super Mare"
+
+  - type: listening
+    name: "🎵 back of the jersey, it say Yaya"
+
+  - type: listening
+    name: "🎵 it's cool you're in college for socioeconomics"
+
+  - type: listening
+    name: "🎵 'cause this room's far too crowded (it's so full)"
+    
+  - type: listening
+    name: "🎵 we get money like the troubles, blow it at the mall"
+    
+  - type: listening
+    name: "🎵 i'm in Turin like Henry, I'm in Barca' like him too"
+
+  # watching things
+  - type: watching
+    name: "Jujutsu Kaisen"
+  
+  - type: watching
+    name: "Frieren: Beyond Journey's End"
+  
+  - type: watching
+    name: "Witch Hat Ateier"
+  
+  - type: watching
+    name: "Steel Ball Run"
+  
+  - type: watching
+    name: "Chainsaw Man"
+  
+  - type: watching
+    name: "Apothecary Diaries"
+  
+  - type: watching
+    name: "old lectures"
+
+  # playing things
+  - type: playing
+    name: "VALORANT"
+  
+  - type: playing
+    name: "Overwatch"
+  
+  - type: playing
+    name: "League of Legends"
+  
+  - type: playing
+    name: "Deadlock"
+  
+  - type: playing
+    name: "The Legend of Zelda"
+  
+  - type: playing
+    name: "Pokemon: Black"

--- a/utils/statuses.py
+++ b/utils/statuses.py
@@ -1,0 +1,17 @@
+import yaml
+import discord
+
+TYPE_MAP = {
+    "listening": discord.ActivityType.listening,
+    "watching": discord.ActivityType.watching,
+    "playing": discord.ActivityType.playing,
+    "competing": discord.ActivityType.competing,
+}
+
+def load_statuses():
+    with open("statuses.yaml", "r") as file:
+        statuses = yaml.safe_load(file)
+    return [
+        discord.Activity(type=TYPE_MAP[status["type"]], name=status["name"])
+        for status in statuses["statuses"]
+    ]


### PR DESCRIPTION
self explanatory, all need "manage channels" permission via a role (not channel perms)

also adds statuses, usable by bot devs (in config) and people with stream team role
- cycling statuses (in statuses.yaml)
- custom manual status via `/status type:custom status:textgoeshere`
- streaming status via `/status type:streaming status:textgoeshere(optional)`, links to twitch in status
- back to default cycle via `/status type:default`